### PR TITLE
Add non-null comment condition to each comment_on call

### DIFF
--- a/lib/sequel/extensions/pg_comment/database_methods.rb
+++ b/lib/sequel/extensions/pg_comment/database_methods.rb
@@ -108,17 +108,17 @@ module Sequel::Postgres::Comment::DatabaseMethods
 			case c[:type]
 			when :primary_key
 				c_name = c[:name] || "#{name}_pkey".to_sym
-				comment_on(:index, c_name, c[:comment])
+				comment_on(:index, c_name, c[:comment]) if c[:comment]
 			when :foreign_key, :check
 				if c[:type] == :check && c[:name].nil?
 					raise Sequel::Error,
 					      "Setting comments on unnamed check constraints is not supported"
 				end
 				c_name = c[:name] || "#{name}_#{c[:columns].first}_fkey".to_sym
-				comment_on(:constraint, [name, c_name], c[:comment])
+				comment_on(:constraint, [name, c_name], c[:comment]) if c[:comment]
 			when :unique
 				c_name = c[:name] || ([name] + c[:columns] + ["key"]).join("_").to_sym
-				comment_on(:index, c_name, c[:comment])
+				comment_on(:index, c_name, c[:comment]) if c[:comment]
 			end
 		end
 	end

--- a/lib/sequel/extensions/pg_comment/database_methods.rb
+++ b/lib/sequel/extensions/pg_comment/database_methods.rb
@@ -105,20 +105,23 @@ module Sequel::Postgres::Comment::DatabaseMethods
 		end
 
 		generator.constraints.each do |c|
+			if c[:type] == :check && c[:name].nil?
+				raise Sequel::Error,
+				      "Setting comments on unnamed check constraints is not supported"
+			end
+
+			next unless c[:comment]
+
 			case c[:type]
 			when :primary_key
 				c_name = c[:name] || "#{name}_pkey".to_sym
-				comment_on(:index, c_name, c[:comment]) if c[:comment]
+				comment_on(:index, c_name, c[:comment])
 			when :foreign_key, :check
-				if c[:type] == :check && c[:name].nil?
-					raise Sequel::Error,
-					      "Setting comments on unnamed check constraints is not supported"
-				end
-				c_name = c[:name] || "#{name}_#{c[:columns].first}_fkey".to_sym
-				comment_on(:constraint, [name, c_name], c[:comment]) if c[:comment]
+					c_name = c[:name] || "#{name}_#{c[:columns].first}_fkey".to_sym
+					comment_on(:constraint, [name, c_name], c[:comment])
 			when :unique
 				c_name = c[:name] || ([name] + c[:columns] + ["key"]).join("_").to_sym
-				comment_on(:index, c_name, c[:comment]) if c[:comment]
+				comment_on(:index, c_name, c[:comment])
 			end
 		end
 	end

--- a/lib/sequel/extensions/pg_comment/version.rb
+++ b/lib/sequel/extensions/pg_comment/version.rb
@@ -1,0 +1,7 @@
+module Sequel
+  module Postgres
+    module Comment
+      VERSION = '2.0.2'
+    end
+  end
+end

--- a/sequel-pg-comment.gemspec
+++ b/sequel-pg-comment.gemspec
@@ -1,10 +1,12 @@
-require 'git-version-bump'
+$:.push File.expand_path("../lib", __FILE__)
+require 'sequel/extensions/pg_comment/version'
+require 'date'
 
 Gem::Specification.new do |s|
 	s.name = "sequel-pg-comment"
 
-	s.version = GVB.version
-	s.date    = GVB.date
+	s.version = Sequel::Postgres::Comment::VERSION
+	s.date    = '2017-05-30'
 
 	s.platform = Gem::Platform::RUBY
 


### PR DESCRIPTION
* Other each blocks over generator.constraints guard against null
  comments however, this block does not due to the error raised
  when trying to set a comment on an unnamed constraint.
