### PR TITLE
YARD comments

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,2 @@
 --markup markdown
+--no-private

--- a/README.md
+++ b/README.md
@@ -25,26 +25,32 @@ That's what this gem is all about.
 
 First, you need to enable the plugin:
 
-    Sequel::Database.extension :pg_comment
+```ruby
+Sequel::Database.extension :pg_comment
+```
 
 Then, you can attach a comment to anything you can create with [Sequel
 schema
 modifications](http://sequel.jeremyevans.net/rdoc/files/doc/schema_modification_rdoc.html)
 by adding a `:comment` option, like so:
 
-    create_table :comments, :comment => "Foo to you too" do
-      primary_key :id, :comment => "Auto-incrementing primary key"
-      String :data, :null => false, :comment => "Markdown"
-      foreign_key :user_id, :users, :comment => "The user who owns the comment"
+```ruby
+create_table :comments, :comment => "Foo to you too" do
+    primary_key :id, :comment => "Auto-incrementing primary key"
+    String :data, :null => false, :comment => "Markdown"
+    foreign_key :user_id, :users, :comment => "The user who owns the comment"
 
-      index :user_id, :comment => "Find those user comments faster!"
-    end
+    index :user_id, :comment => "Find those user comments faster!"
+end
+```
 
 For some object types, though, there's no syntactic sugar in Sequel, so
 you've got to create them by hand.  Never fear, though!  You can comment on
 any object using Ruby code, like so:
 
-    comment_on :collation, :my_collation, "Collate ALL THE THINGS!"
+```ruby
+comment_on :collation, :my_collation, "Collate ALL THE THINGS!"
+```
 
 This is useful also for tables, where you might not want to insert a lengthy
 comment in the top of your `create_table` block.
@@ -53,26 +59,31 @@ The `table.column` syntax that PgSQL requires for `COMMENT ON COLUMN` can be
 simulated in the usual Sequel fashion, of using two underscores in the
 symbol to separate the table name from the column name, like so:
 
-    comment_on :column, :foo__bar_id, %{
-      This is my column.  There are many like it, but this one is mine.
-    }
-    #  => COMMENT ON COLUMN "foo"."bar_id" IS 'This is my column. (etc)'
+```ruby
+comment_on :column, :foo__bar_id, %{
+    This is my column.  There are many like it, but this one is mine.
+}
+#  => COMMENT ON COLUMN "foo"."bar_id" IS 'This is my column. (etc)'
+```
 
 **NOTE**: The object you wish to comment on *must already exist* before you
 call `comment_on`.  The following example **WILL NOT WORK**:
 
-    comment_on :table, :foo, "This is an awesomely foo table"
-    create_table :foo, do
-      # ...
-    end
+```ruby
+comment_on :table, :foo, "This is an awesomely foo table"
+create_table :foo, do
+  # ...
+end
+```
 
 You have to put the `comment_on` *after* the `create_table`, like this:
 
-    create_table :foo, do
-      # ...
-    end
-    comment_on :table, :foo, "This is an awesomely foo table"
-
+```ruby
+create_table :foo, do
+  # ...
+end
+comment_on :table, :foo, "This is an awesomely foo table"
+```
 
 ## Comment string tidy-up
 
@@ -91,38 +102,44 @@ and that is to strip out leading whitespace.  The rules are very simple:
 That means you can use a heredoc for your multi-line comments, and they'll
 still look neat and tidy without having to play `gsub` tricks:
 
-    create_table :foo do
-      String :data, :comment => <<-EOF
-        This is a very lengthy comment.  It goes for many lines
-        and has a great deal to say on any number of subjects.  I
-        could have used lorem ipsum here, but I prefer to do things
-        the old-fashioned way.  If you've read all of this example,
-        you probably stay to read the whole of the credits at the
-        cinema.  Good for you!  I do too.  Wave next time, you
-        anti-social loner.
-      EOF
-    end
+```ruby
+create_table :foo do
+  String :data, :comment => <<-EOF
+    This is a very lengthy comment.  It goes for many lines
+    and has a great deal to say on any number of subjects.  I
+    could have used lorem ipsum here, but I prefer to do things
+    the old-fashioned way.  If you've read all of this example,
+    you probably stay to read the whole of the credits at the
+    cinema.  Good for you!  I do too.  Wave next time, you
+    anti-social loner.
+  EOF
+end
+```
 
 One caveat: it's common to use the `%( ... )` quoting style for lengthy
 strings.  That's fine, but make sure to put the first line of docs on its
 own line, and not directly after the `%(`.  For example, this will not work
 so well:
 
-    # This WILL NOT trim leading whitespace from each line
-    comment_on :table, :foo, %(This is a long comment.
-      However, due to the way that pg-comment trims whitespace,
-      these lines will have leading indents, because the first line
-      didn't.
-    )
+```ruby
+# This WILL NOT trim leading whitespace from each line
+comment_on :table, :foo, %(This is a long comment.
+  However, due to the way that pg-comment trims whitespace,
+  these lines will have leading indents, because the first line
+  didn't.
+)
+```
 
 Instead, you'll want to do this:
 
-    # This WILL trim leading whitespace from each line
-    comment_on :table, :foo, %(
-      This, too, is a long comment.  Because the first non-empty
-      line had leading spaces, all of these other lines will have
-      their leaving spaces stripped too.
-    )
+```ruby
+# This WILL trim leading whitespace from each line
+comment_on :table, :foo, %(
+  This, too, is a long comment.  Because the first non-empty
+  line had leading spaces, all of these other lines will have
+  their leaving spaces stripped too.
+)
+```
 
 As always, inconsistent use of tabs and spaces will end in disaster.  So
 don't do that.  Remember: tabs are for indenting, spaces are for formatting.
@@ -178,15 +195,21 @@ It's great that this gem can help you to document your database, but that's
 not much use if nobody can read them again.  Within Sequel itself, you can
 retrieve comments quite easily:
 
-    DB.comment_for(:foo)  # => "Something something dark side"
+```ruby
+DB.comment_for(:foo)  # => "Something something dark side"
+```
 
 For columns, you can either use the double underscore notation:
 
-    DB.comment_for(:foo__column)  # => "Awwwwww yeah"
+```ruby
+DB.comment_for(:foo__column)  # => "Awwwwww yeah"
+```
 
 Or you can do the same thing from the dataset itself:
 
-    DB[:foo].comment_for(:column)  # => "Awwwwww yeah"
+```ruby
+DB[:foo].comment_for(:column)  # => "Awwwwww yeah"
+```
 
 There's currently no support for retrieving a database comment from a Sequel
 model; pull requests implementing such a feature would be warmly welcomed.

--- a/lib/sequel/extensions/pg_comment.rb
+++ b/lib/sequel/extensions/pg_comment.rb
@@ -61,8 +61,9 @@ module Sequel::Postgres::Comment
 	#
 	# This means you can use heredocs and multi-line strings without having
 	# to play your own silly-buggers in order to not make the comments look
-	# like arse.  If you like heredocs, you're encouraged to use this style:
+	# like arse.  If you like heredocs, you're encouraged to use that style.
 	#
+	# @example Heredoc-style works
 	#    comment_for :table, :foo, <<-EOF
 	#      This is my comment.
 	#
@@ -70,8 +71,9 @@ module Sequel::Postgres::Comment
 	#    EOF
 	#
 	# On the other hand, if percent-quotes are more your cup of tea, you can
-	# go at them like this:
+	# use those.
 	#
+	# @example Percent-quote style works
 	#    comment_for :table, :foo, %(
 	#      This is my comment.
 	#
@@ -81,8 +83,9 @@ module Sequel::Postgres::Comment
 	# Be sure to not start the first line of your comment on the same line as
 	# the quote character, though, because that will mean the first line of
 	# the comment *doesn't* have any leading whitespace, and so whitespace
-	# won't be trimmed from the rest of the comment.  So, don't do this:
+	# won't be trimmed from the rest of the comment.  So, don't do that.
 	#
+	# @example This will not work
 	#    comment_for :table, :foo, %(This won't work at all well.
 	#      Since the first line of text doesn't have leading whitespace,
 	#      these lines won't have it stripped either, and everything will

--- a/lib/sequel/extensions/pg_comment/database_methods.rb
+++ b/lib/sequel/extensions/pg_comment/database_methods.rb
@@ -95,6 +95,7 @@ module Sequel::Postgres::Comment::DatabaseMethods
 	# Enhanced to support creating comments on columns, after the table
 	# itself (and hence all its columns) have been created.
 	#
+	# @private
 	def create_table_from_generator(name, generator, options)
 		super
 
@@ -127,6 +128,7 @@ module Sequel::Postgres::Comment::DatabaseMethods
 	# Enhanced to support creating comments on indexes, after the indexes
 	# themselves have been created.
 	#
+	# @private
 	def create_table_indexes_from_generator(name, generator, options)
 		super
 
@@ -142,6 +144,7 @@ module Sequel::Postgres::Comment::DatabaseMethods
 	# Enhanced version to support setting comments on objects created in a
 	# block-form `alter_table` statement.
 	#
+	# @private
 	def apply_alter_table_generator(name, generator)
 		super
 

--- a/lib/sequel/extensions/pg_comment/dataset_methods.rb
+++ b/lib/sequel/extensions/pg_comment/dataset_methods.rb
@@ -1,11 +1,10 @@
 # Support for retrieving column comments from a PostgreSQL database
-# via a dataset.  For example:
+# via a dataset.
 #
-#    DB[:foo_tbl].comment_for(:some_column)
-#
-# Will retrieve the comment for `foo_tbl.some_column`, if such a
-# column exists.
-#
+# @example Retrieve the comment for `foo_tbl.some_column`
+#    DB[:foo_tbl].comment_for(:some_column) # => 'the comment for that column'
+# @example Retrieve the comment for a non-existent column
+#    DB[:foo_tbl].comment_for(:not_a_column) # => nil
 module Sequel::Postgres::Comment::DatasetMethods
 	# Retrieve the comment for the column named `col` in the "primary" table
 	# for this dataset.


### PR DESCRIPTION
This PR adds documentation commentary (by adding `@example` markers so that YARD can represent it prettier where it's rendered) and GitHub code fences to the code examples in the README.