### PR TITLE
Allow commenting on materialized view during create_view

### DIFF
--- a/lib/sequel/extensions/pg_comment/database_methods.rb
+++ b/lib/sequel/extensions/pg_comment/database_methods.rb
@@ -187,7 +187,11 @@ module Sequel::Postgres::Comment::DatabaseMethods
 		super
 
 		if args.last.is_a?(Hash) && args.last[:comment]
-			comment_on(:view, args.first, args.last[:comment])
+			if args.last[:materialized]
+				comment_on(:materialized_view, args.first, args.last[:comment])
+			else
+				comment_on(:view, args.first, args.last[:comment])
+			end
 		end
 	end
 

--- a/spec/create_view_comment_spec.rb
+++ b/spec/create_view_comment_spec.rb
@@ -6,7 +6,7 @@ describe "#create_view" do
 		Sequel.connect("mock://postgres").extension(:pg_comment)
 	end
 
-	it "sets a table comment" do
+	it "sets a table comment on a view" do
 		db.create_view(
 		  :gold_albums,
 		  db[:albums].where { copies_sold > 500_000 },
@@ -14,5 +14,16 @@ describe "#create_view" do
 		)
 		expect(db.sqls.last).
 		  to eq("COMMENT ON VIEW \"gold_albums\" IS 'Rich!'")
+	end
+
+	it "sets a table comment on a materialized view" do
+		db.create_view(
+			:gold_albums_mv,
+			db[:albums].where { copies_sold > 500_000 },
+			:comment => "Rich!",
+			:materialized => true,
+		)
+		expect(db.sqls.last).
+			to eq("COMMENT ON MATERIALIZED VIEW \"gold_albums_mv\" IS 'Rich!'")
 	end
 end


### PR DESCRIPTION
When passing the `:materialized` option to [create_view](https://sequel.jeremyevans.net/rdoc/classes/Sequel/Database.html#method-i-create_view), a materialized view is created, which must be commented on using `COMMENT ON MATERIALIZED VIEW`. This PR makes that happen.

Previously an exception would be raised when attempting to comment a materialized view via `create_view`:

    PG::WrongObjectType: ERROR:  "my_mv" is not a view: COMMENT ON VIEW "my_mv"